### PR TITLE
[BUGFIX]-Correção no formato de retorno do CSV

### DIFF
--- a/backend/routes/forms.js
+++ b/backend/routes/forms.js
@@ -163,10 +163,9 @@ router.get('/converter_respostas/:id', (req, res) => {
         var id = req.params.id
         function arrayToCSV(objArray) {
             const array = typeof objArray !== 'object' ? JSON.parse(objArray) : objArray;
-            let str = `${Object.keys(array[0]).map(value => `"${value}"`).join(",")}` + '\r\n';
-            let fields = str
+            let str = `${Object.keys(array[0]).map(value => `"${value}"`).join(";")}` + '\r\n';
             return array.reduce((str, next) => {
-                str += `${Object.values(next).map(value => `"${value}"`).join(",")}` + '\r\n';
+                str += `${Object.values(next).map(value => `"${value}"`).join(";")}` + '\r\n';
                 return str;
             }, str);
         }


### PR DESCRIPTION
# Issue Relacionada
* Nenhuma Issue relacionada

# Tipo de mudança
- [x] Bugfix  
- [ ] Nova funcionalidade  
- [ ] Alteração de funcionalidade
- [ ] Outro

# Descrição
* A virgula no código de conversão foi trocada por um ponto e virgula. Apesar de ser uma mudança mínima é fundamental para o formato do CSV, antes da mudança as perguntas estavam somente separadas por virgulas o que dificultava na hora de extrair os dados do CSV matando totalmente o proposito do mesmo. Após a mudança os dados estão sendo exibidos em colunas separadas, facilitando a leitura e extração de dados.