### PR TITLE
Resolvendo bug que apagava sempre o primeiro questionario

### DIFF
--- a/backend/routes/forms.js
+++ b/backend/routes/forms.js
@@ -192,8 +192,8 @@ router.get('/converter_respostas/:id', (req, res) => {
 router.get('/delete/:id', (req, res) => {
     if (req.user) {
         let id = req.params.id;
-        modelFormulario.findOneAndDelete(id).then(() => {
-            console.log('deletado')
+        modelFormulario.findByIdAndRemove(id).then(() => {
+            console.log('deletado');
             res.redirect('/forms')
         }).catch((err) => {
             console.log(err)


### PR DESCRIPTION
# Issue Relacionada
* Esse *pull request* não resolve nenhuma issue, apenas corrige bugs

# Tipo de mudança
- [x] Bugfix  
- [ ] Nova funcionalidade  
- [ ] Alteração de funcionalidade
- [ ] Outro

# Descrição
* O bug de apagar somente o primeiro questionário foi corrigido da seguinte forma. Na rota de deletar questionários no Backend a tag do mongoose FindOneAndDelete(id), foi substituida pela tag FindByIdAndDelete(id).
* Contudo, o motivo de o FindOneAndDelete(id) ter funcionado nas versões anteriores ainda é desconhecido.
