### PR TITLE
118 botao overlay delete

### DIFF
--- a/frontend/public/listagem_formulario/js/deleteForm.js
+++ b/frontend/public/listagem_formulario/js/deleteForm.js
@@ -1,5 +1,5 @@
 deleteForm = (formId, formName) => {
-    document.getElementById("DeleteModalInterno").innerHTML = formName;
+    document.getElementById("ModalInternoDelete").innerHTML = formName;
     document.getElementById("delete").href = '/forms/delete/'+formId;
     console.log('/forms/delete/'+formId);   
 }

--- a/frontend/public/listagem_formulario/styles/listForms.css
+++ b/frontend/public/listagem_formulario/styles/listForms.css
@@ -1,5 +1,6 @@
 body{
     background: white;
+    display: contents;
 }
 .formBox{
     min-height: 100px;

--- a/frontend/public/listagem_formulario/styles/overlay.css
+++ b/frontend/public/listagem_formulario/styles/overlay.css
@@ -7,4 +7,6 @@
   position: absolute;
   left: -999em;
 }
-  
+.modal-open {
+  overflow: auto; 
+ }

--- a/frontend/public/manter_formulario/styles/novoformulario.css
+++ b/frontend/public/manter_formulario/styles/novoformulario.css
@@ -1,3 +1,8 @@
+body{
+  background: white;
+  display: contents;
+}
+
 .backGround {
   display: flex;
   justify-content: space-evenly;  

--- a/frontend/views/formularios/inicio.ejs
+++ b/frontend/views/formularios/inicio.ejs
@@ -11,6 +11,7 @@
 </head>
 <%- include ../partials/Header.ejs%>
 <%- include ../partials/Overlay.ejs%>
+<%- include ../partials/OverlayDelete.ejs%>
 
 <body>
   <% if (formulario.length>0) { %>
@@ -35,7 +36,8 @@
                 <i class="fas fa-chart-bar" id="buttonIcon"></i>
               </div>
             </a>
-            <a onclick="return confirm('Tem certeza que deseja excluir o questionário?');" href="/forms/delete/<%= formulario[i].id %>">
+            <!-- href="/forms/delete/<%= formulario[i].id %>" -->
+            <a onclick="deleteForm('<%=formulario[i].id%>','<%=formulario[i].nome%>')" data-toggle="modal" data-target="#ModalPrincipalDelete" style="cursor:pointer;">
               <div class="buttonForm" style="background: #FF2C2C">
                 <i class="fas fa-trash" id="buttonIcon"></i>
               </div>

--- a/frontend/views/partials/OverlayDelete.ejs
+++ b/frontend/views/partials/OverlayDelete.ejs
@@ -1,0 +1,38 @@
+<head>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
+        integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+        sintegrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+        crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"
+        integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49"
+        crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
+        integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
+        crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="/listagem_formulario/styles/overlay.css">
+    <script src="/listagem_formulario/js/deleteForm.js"></script>
+</head>
+<div class="modal fade" id="ModalPrincipalDelete" tabindex="-1" role="dialog" aria-labelledby="ModalInterno"
+    aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title" id="ModalInternoDelete" Deletestyle="color: rgb(120, 120, 120)"></h4>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Fechar">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="boxOverlay">
+                <button type="button" class="btn btn-danger btn-lg" onclick="confirmDelete()" data-dismiss="modal"
+                    style="margin-top: 10px; margin-bottom: 10px">
+                    <a id="delete" href="#" style="text-decoration: none; color: white;">Apagar</a>
+                </buttontype="button">
+                <button type="button" class="btn btn-primary btn-lg" data-dismiss="modal"
+                    style="margin-top: 10px; margin-bottom: 10px">
+                    Cancelar
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/frontend/views/partials/OverlayDelete.ejs
+++ b/frontend/views/partials/OverlayDelete.ejs
@@ -14,7 +14,7 @@
     <script src="/listagem_formulario/js/deleteForm.js"></script>
 </head>
 <div class="modal fade" id="ModalPrincipalDelete" tabindex="-1" role="dialog" aria-labelledby="ModalInterno"
-    aria-hidden="true">
+    aria-hidden="true" style="overflow: auto">
     <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header">
@@ -31,7 +31,7 @@
                 <button type="button" class="btn btn-primary btn-lg" data-dismiss="modal"
                     style="margin-top: 10px; margin-bottom: 10px">
                     Cancelar
-                </button>
+                </button>   
             </div>
         </div>
     </div>


### PR DESCRIPTION
# Issue Relacionada
* Esse *pull request* resolve a issue #118 

# Tipo de mudança
- [ ] Bugfix  
- [ ] Nova funcionalidade  
- [x] Alteração de funcionalidade
- [ ] Outro

# Descrição
* Agora a caixa de confirmação de deletar formulários está seguindo o padrão utilizado no projeto. 
* O bug que estava ocorrendo de shift para a esquerda de todo o conteúdo da página, quando um overlay era renderizado, também foi corrigido.  
