### PR TITLE
Adição de labels para o evento hover sobre as opções.

### DIFF
--- a/frontend/views/formularios/cadastro_formulario.ejs
+++ b/frontend/views/formularios/cadastro_formulario.ejs
@@ -32,14 +32,12 @@
 		<form id="form_registro" method="POST" action="/forms/registro/salvar">
 			<div>
 				<div style="display: flex; justify-content: center;">
-					<input type="text" id="name_quest" name="name_quest" placeholder="Nome do questionário"
-						class="textBoxName">
+					<input type="text" id="name_quest" name="name_quest" placeholder="Nome do questionário" class="textBoxName">
 				</div>
 				<div class="pageDimension">
 					<div style="display: flex; flex-direction: column;">
 						<label for="copy_marskdown" class="textTitles">Conteúdo</label>
-						<textarea id="notes" name="copy_markdown" placeholder=" Markdown" class="textBox"
-							onkeyup="stylizePreview()"></textarea>
+						<textarea id="notes" name="copy_markdown" placeholder=" Markdown" class="textBox" onkeyup="stylizePreview()"></textarea>
 					</div>
 					<div style="display: flex; flex-direction: column;">
 						<label class="textTitles">Preview</label>
@@ -51,11 +49,11 @@
 			</div>
 			<div style="float: right; margin-top: 15px; flex-direction: row; display:flex">
 				<a onclick="window.location.href='/forms'">
-					<div class="buttonOptionDiv" style="background-color: rgb(255, 0, 0);">
+					<div class="buttonOptionDiv" style="background-color: rgb(255, 0, 0);" title="Cancelar">
 						<i class="fas fa-times" style="color: white" id="buttonIcon"></i>
 					</div>
 				</a>
-				<button type="submit" class="buttonOption" style="background: rgb(15, 225, 20);">
+				<button type="submit" class="buttonOption" style="background: rgb(15, 225, 20);" title="Cadastrar">
 					<i class="fas fa-check" style="color: white"></i>
 				</button>
 			</div>
@@ -96,8 +94,6 @@
 			document.getElementById('notes-preview').innerHTML = wmd.previewMgr.output();
 			stylizeFields(recoverInputsInformation());
 		};
-
 	</script>
 </body>
-
 </html>

--- a/frontend/views/formularios/editar_formulario.ejs
+++ b/frontend/views/formularios/editar_formulario.ejs
@@ -52,11 +52,11 @@
 			</div>
 			<div style="float: right; margin-top: 15px; flex-direction: row; display:flex">
 				<a onclick="window.location.href='/forms'">
-					<div class="buttonOptionDiv" style="background-color: rgb(255, 0, 0);">
+					<div class="buttonOptionDiv" style="background-color: rgb(255, 0, 0);" title="Cancelar">
 						<i class="fas fa-times" style="color: white" id="buttonIcon"></i>
 					</div>
 				</a>
-				<button type="submit" class="buttonOption" style="background: rgb(15, 225, 20);">
+				<button type="submit" class="buttonOption" style="background: rgb(15, 225, 20);" title="Salvar">
 					<i class="fas fa-check" style="color: white"></i>
 				</button>
 			</div>

--- a/frontend/views/formularios/inicio.ejs
+++ b/frontend/views/formularios/inicio.ejs
@@ -22,31 +22,31 @@
       <div class="formText"><%= formulario[i].nome%></div>
       <div class="buttonsBox">
         <a href="/forms/editar/<%= formulario[i].id %>">
-          <div class="buttonForm" style="background: #00AAFF">
+          <div class="buttonForm" style="background: #00AAFF" title="Editar">
             <i class="fa fa-pencil" id="buttonIcon"></i>
           </div>
         </a>
         <a onclick="getInfo('<%=formulario[i].id%>','<%=formulario[i].nome%>')" data-toggle="modal"
           data-target="#ModalPrincipal" style="cursor:pointer;">
-          <div class="buttonForm" style="background: #77D353">
+          <div class="buttonForm" style="background: #77D353" title="Compartilhar">
             <i class="fas fa-share-alt" id="buttonIcon"></i>
           </div>
         </a>
         <a href="/forms/dashboard/<%= formulario[i].id %>">
-          <div class="buttonForm" style="background: #4B2CFF">
+          <div class="buttonForm" style="background: #4B2CFF" title="Dashboard">
             <i class="fas fa-chart-bar" id="buttonIcon"></i>
           </div>
         </a>
         <a onclick="deleteForm('<%=formulario[i].id%>','<%=formulario[i].nome%>')" data-toggle="modal"
           data-target="#ModalPrincipalDelete" style="cursor:pointer;">
-          <div class="buttonForm" style="background: #FF2C2C">
+          <div class="buttonForm" style="background: #FF2C2C" title="Deletar">
             <i class="fas fa-trash" id="buttonIcon"></i>
           </div>
         </a>
       </div>
     </div>
     <% } %>
-    <a href="/forms/registro" class="newFormButton">+</a>
+    <a href="/forms/registro" class="newFormButton" title="Cadastrar">+</a>
   </div>
   <% }else{ %>
   <div class="nothingHere">

--- a/frontend/views/usuarios/criar_conta.ejs
+++ b/frontend/views/usuarios/criar_conta.ejs
@@ -22,7 +22,7 @@
 </head>
 
 <body>
-    <div class="shine" onclick="window.location.href='/'">QM</div>
+    <div class="shine" onclick="window.location.href='/'" title="Home">QM</div>
     <div class="box">
         <form id="formUser" class="loginBox" action="/users/criar_conta" method="POST">
                 

--- a/frontend/views/usuarios/login.ejs
+++ b/frontend/views/usuarios/login.ejs
@@ -24,7 +24,7 @@
         </div>
     </div>
     <% } %>
-    <div class="shine" onclick="window.location.href='/'">QM</div>
+    <div class="shine" onclick="window.location.href='/'" title="Home">QM</div>
     <div class="box">
         <form action="/users/autenticar" method="POST" class="loginBox">
             <label for="email" class="textLabel"><b>Email</b></label>


### PR DESCRIPTION
# Tipo de mudança
- [ ] Bugfix  
- [x] Nova funcionalidade  
- [ ] Alteração de funcionalidade
- [ ] Outro

# Descrição
##### Adição de _labels_ que indicam a funcionalidade quando o evento _hover_(quando o mouse estiver sobre um _container_) é acionado, dessa foma, facilitando a navegabilidade dentro da plataforma. Views que receberam essa funcionalidade:
* Login (para o botão QM);
* Cadastro de usuário (para o botão QM);
* Início após login (para cada botão dos questionários + botão de cadastro de questionário);
* Editar questionário (botão cadastrar e botão cancelar);
* Cadastro de questionário (botão cadastrar e botão cancelar);

# Comentários
* Demonstração: 
![labels-hover](https://user-images.githubusercontent.com/36088551/69442900-1c230280-0d2c-11ea-8dc7-3582fa0d7dde.gif)